### PR TITLE
Raise the Test Coverage

### DIFF
--- a/src/main/java/models/Game.java
+++ b/src/main/java/models/Game.java
@@ -325,7 +325,7 @@ public class Game implements Serializable {
         if(hasSplit && (!secondStand)){
                 againDisabled = true;
                 firstStand = true;
-            } else if (hasSplit && secondStand){
+        } else if (hasSplit && secondStand){
             player.emptySecondHand(deck);
             shuffle();
         }

--- a/src/test/java/models/testGame.java
+++ b/src/test/java/models/testGame.java
@@ -155,10 +155,12 @@ public class testGame {
         g.player.addCard(new Card(10, Suit.Diamonds));
         g.player.addCard(new Card(3, Suit.Spades));
         assertEquals(g.player.getCount(), 23);
+        g.player.addSecondHandCard(new Card(3, Suit.Hearts));
         g.newHand();
         assertEquals(false, g.errorFlag);
         assertEquals(0, g.player.getCount());
         assertEquals(true,g.againDisabled);
+        assertEquals(0, g.player.getSecondHand().size());
     }
 
     /*
@@ -177,13 +179,19 @@ public class testGame {
     */
 
     @Test
-    public void doubleDown(){
+    public void testDoubleDown(){
         Game g = new Game();
         g.tryBet(5);
         g.tryDeal();
+        g.player.emptyHand(g.deck);
+        g.player.addCard(new Card(5, Suit.Hearts));
+        g.player.addCard(new Card(6, Suit.Clubs));
         g.doubleDown();
         assertEquals(10,g.player.getBet());
         assertEquals(3, g.player.getHand().size());
+        g.player.addCard(new Card(13, Suit.Spades));
+        g.doubleDown();
+        assertEquals(true, g.player.getCount() > 21);
     }
 
 
@@ -201,5 +209,51 @@ public class testGame {
         assertEquals(false, g.errorFlag);
         assertNotSame(0, g.dealer.getCount());
 
+    }
+
+    @Test
+    public void testSplit(){
+        Game g = new Game();
+        g.tryBet(5);
+        g.player.addCard(new Card(1, Suit.Diamonds));
+        g.player.addCard(new Card(1, Suit.Hearts));
+        g.split();
+        String msg = "Hit or Stand";
+        assertEquals(true, msg.equals(g.userMessage));
+        assertEquals(true, msg.equals(g.userMessageTwo));
+    }
+
+    @Test
+    public void testHitTwo(){
+        Game g = new Game();
+        g.hitTwo();
+        assertEquals(true, g.doubleDownTwoDisabled);
+        for(int i = 0; i < 4; ++i)
+            g.hitTwo();
+        assertEquals(true, g.secondStand);
+        String msg = "You bust";
+        assertEquals(true, msg.equals(g.userMessageTwo));
+    }
+
+    @Test
+    public void testStandTwo(){
+        Game g = new Game();
+        g.player.addSecondHandCard(new Card(10, Suit.Diamonds));
+        g.player.addSecondHandCard(new Card(1, Suit.Hearts));
+        g.standTwo();
+        assertEquals(true, g.secondStand);
+    }
+
+    @Test
+    public void testDoubleDownTwo(){
+        Game g = new Game();
+        g.player.setBetTwo(5);
+        g.doubleDownTwo();
+        assertEquals(1, g.player.getSecondHand().size());
+        for(int i = 0; i < 2; ++i)
+            g.player.addSecondHandCard(new Card(13, Suit.Spades));
+        g.doubleDownTwo();
+        String msg = "You bust";
+        assertEquals(true, msg.equals(g.userMessageTwo));
     }
 }

--- a/src/test/java/models/testPlayer.java
+++ b/src/test/java/models/testPlayer.java
@@ -1,5 +1,6 @@
 package models;
 
+import org.apache.commons.lang.ObjectUtils;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -28,5 +29,47 @@ public class testPlayer {
         p.setBet(20);
         assertEquals(p.getBank(), 80);
         assertEquals(p.getBet(), 20);
+    }
+
+    @Test
+    public void testPlayerConstructor(){
+        Player p = new Player();
+        assertEquals(0, p.getBank());
+        assertNotEquals(null, p.getSecondHand());
+        assertEquals(0, p.getSecondCount());
+        assertEquals(0, p.getBetTwo());
+    }
+
+    @Test
+    public void testWinBlackJack(){
+        Player p = new Player(100);
+        p.setBet(10);
+        p.winBlackJack(1);
+        assertEquals(115, p.getBank());
+        p.setBetTwo(10);
+        p.winBlackJack(0);
+        assertEquals(140,p.getBank());
+    }
+
+    @Test
+    public void testSetSecondHand(){
+        Player p = new Player(100);
+        java.util.List<Card> temp = new ArrayList<>();
+        for(int i = 0; i < 2; ++i)
+            temp.add(new Card(2, Suit.Clubs));
+        p.setSecondHand(temp);
+        assertEquals(temp, p.getSecondHand());
+        assertEquals(4, p.getSecondCount());
+    }
+
+    @Test
+    public void testEmptySecondHand(){
+        Player p = new Player(100);
+        for(int i = 0; i < 2; ++i)
+            p.addSecondHandCard(new Card(1, Suit.Clubs));
+        java.util.List<Card> temp = new ArrayList<>();
+        p.emptySecondHand(temp);
+        assertEquals(0, p.getSecondHand().size());
+        assertEquals(0, p.getSecondCount());
     }
 }


### PR DESCRIPTION
Before this the test coverage was around ~53%. Now it sits around ~85%.

Because shuffle() was incorporated into the constructor their is a sort of random effect when we call the tests. Old tests trigger some lines one time and never touch them another. This causes the test coverage to vary by about a 2-3% margin.

The biggest offender is the game class. Least amount of tests and the most variability
